### PR TITLE
Add product CRUD with authorization

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -58,6 +58,199 @@ const docTemplate = `{
                 }
             }
         },
+        "/products": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "get products",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "List products",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/product.Product"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "create a product",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Create product",
+                "parameters": [
+                    {
+                        "description": "Product",
+                        "name": "product",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    }
+                }
+            }
+        },
+        "/products/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "get product by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Get product by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "update a product by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Update product",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Product",
+                        "name": "product",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "delete a product by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Delete product",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/register": {
             "post": {
                 "description": "register a new user",
@@ -318,6 +511,20 @@ const docTemplate = `{
                 }
             }
         },
+        "product.Product": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                }
+            }
+        },
         "user.User": {
             "type": "object",
             "properties": {
@@ -351,8 +558,8 @@ var SwaggerInfo = &swag.Spec{
 	Host:             "localhost:8080",
 	BasePath:         "/",
 	Schemes:          []string{},
-	Title:            "User API",
-	Description:      "Simple user API with Gin and Swagger",
+	Title:            "User and Product API",
+	Description:      "Simple user and product API with Gin and Swagger",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,8 +1,8 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Simple user API with Gin and Swagger",
-        "title": "User API",
+        "description": "Simple user and product API with Gin and Swagger",
+        "title": "User and Product API",
         "contact": {},
         "version": "1.0"
     },
@@ -45,6 +45,199 @@
                     },
                     "401": {
                         "description": "invalid credentials",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/products": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "get products",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "List products",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/product.Product"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "create a product",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Create product",
+                "parameters": [
+                    {
+                        "description": "Product",
+                        "name": "product",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    }
+                }
+            }
+        },
+        "/products/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "get product by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Get product by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "update a product by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Update product",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Product",
+                        "name": "product",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/product.Product"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "delete a product by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Delete product",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Product ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
                         "schema": {
                             "type": "string"
                         }
@@ -309,6 +502,20 @@
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "product.Product": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -18,6 +18,15 @@ definitions:
       name:
         type: string
     type: object
+  product.Product:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      price:
+        type: number
+    type: object
   user.User:
     properties:
       email:
@@ -32,8 +41,8 @@ definitions:
 host: localhost:8080
 info:
   contact: {}
-  description: Simple user API with Gin and Swagger
-  title: User API
+  description: Simple user and product API with Gin and Swagger
+  title: User and Product API
   version: "1.0"
 paths:
   /login:
@@ -64,6 +73,127 @@ paths:
       summary: Login user
       tags:
       - auth
+  /products:
+    get:
+      description: get products
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/product.Product'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List products
+      tags:
+      - products
+    post:
+      consumes:
+      - application/json
+      description: create a product
+      parameters:
+      - description: Product
+        in: body
+        name: product
+        required: true
+        schema:
+          $ref: '#/definitions/product.Product'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/product.Product'
+      security:
+      - BearerAuth: []
+      summary: Create product
+      tags:
+      - products
+  /products/{id}:
+    delete:
+      description: delete a product by ID
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            type: string
+        "404":
+          description: not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Delete product
+      tags:
+      - products
+    get:
+      description: get product by ID
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/product.Product'
+        "404":
+          description: not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get product by ID
+      tags:
+      - products
+    put:
+      consumes:
+      - application/json
+      description: update a product by ID
+      parameters:
+      - description: Product ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Product
+        in: body
+        name: product
+        required: true
+        schema:
+          $ref: '#/definitions/product.Product'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/product.Product'
+        "404":
+          description: not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update product
+      tags:
+      - products
   /register:
     post:
       consumes:

--- a/internal/product/handler.go
+++ b/internal/product/handler.go
@@ -1,0 +1,128 @@
+package product
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler handles HTTP requests for products.
+type Handler struct {
+	service Service
+}
+
+// NewHandler creates a new Handler.
+func NewHandler(s Service) *Handler {
+	return &Handler{service: s}
+}
+
+// GetProducts godoc
+// @Summary      List products
+// @Description  get products
+// @Tags         products
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {array}   Product
+// @Router       /products [get]
+func (h *Handler) GetProducts(c *gin.Context) {
+	c.JSON(http.StatusOK, h.service.GetAll())
+}
+
+// GetProduct godoc
+// @Summary      Get product by ID
+// @Description  get product by ID
+// @Tags         products
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id   path      int  true  "Product ID"
+// @Success      200  {object}  Product
+// @Failure      404  {string}  string  "not found"
+// @Router       /products/{id} [get]
+func (h *Handler) GetProduct(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	product, ok := h.service.GetByID(id)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+	c.JSON(http.StatusOK, product)
+}
+
+// CreateProduct godoc
+// @Summary      Create product
+// @Description  create a product
+// @Tags         products
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        product  body      Product  true  "Product"
+// @Success      201   {object}  Product
+// @Router       /products [post]
+func (h *Handler) CreateProduct(c *gin.Context) {
+	var product Product
+	if err := c.ShouldBindJSON(&product); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	created := h.service.Create(product)
+	c.JSON(http.StatusCreated, created)
+}
+
+// UpdateProduct godoc
+// @Summary      Update product
+// @Description  update a product by ID
+// @Tags         products
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id    path      int       true  "Product ID"
+// @Param        product  body      Product true  "Product"
+// @Success      200   {object}  Product
+// @Failure      404   {string}  string    "not found"
+// @Router       /products/{id} [put]
+func (h *Handler) UpdateProduct(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var product Product
+	if err := c.ShouldBindJSON(&product); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	updated, ok := h.service.Update(id, product)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+	c.JSON(http.StatusOK, updated)
+}
+
+// DeleteProduct godoc
+// @Summary      Delete product
+// @Description  delete a product by ID
+// @Tags         products
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id   path      int  true  "Product ID"
+// @Success      204  {string}  string  ""
+// @Failure      404  {string}  string  "not found"
+// @Router       /products/{id} [delete]
+func (h *Handler) DeleteProduct(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if !h.service.Delete(id) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/product/model.go
+++ b/internal/product/model.go
@@ -1,0 +1,8 @@
+package product
+
+// Product represents a product in the system.
+type Product struct {
+	ID    int     `json:"id"`
+	Name  string  `json:"name"`
+	Price float64 `json:"price"`
+}

--- a/internal/product/repository.go
+++ b/internal/product/repository.go
@@ -1,0 +1,58 @@
+package product
+
+// Repository defines methods for product data access.
+type Repository interface {
+	GetAll() []Product
+	GetByID(id int) (Product, bool)
+	Create(product Product) Product
+	Update(id int, product Product) (Product, bool)
+	Delete(id int) bool
+}
+
+// InMemoryRepository is an in-memory implementation of Repository.
+type InMemoryRepository struct {
+	data   map[int]Product
+	lastID int
+}
+
+// NewInMemoryRepository creates a new in-memory repository.
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{data: make(map[int]Product)}
+}
+
+func (r *InMemoryRepository) GetAll() []Product {
+	products := make([]Product, 0, len(r.data))
+	for _, p := range r.data {
+		products = append(products, p)
+	}
+	return products
+}
+
+func (r *InMemoryRepository) GetByID(id int) (Product, bool) {
+	p, ok := r.data[id]
+	return p, ok
+}
+
+func (r *InMemoryRepository) Create(product Product) Product {
+	r.lastID++
+	product.ID = r.lastID
+	r.data[product.ID] = product
+	return product
+}
+
+func (r *InMemoryRepository) Update(id int, product Product) (Product, bool) {
+	if _, ok := r.data[id]; !ok {
+		return Product{}, false
+	}
+	product.ID = id
+	r.data[id] = product
+	return product, true
+}
+
+func (r *InMemoryRepository) Delete(id int) bool {
+	if _, ok := r.data[id]; !ok {
+		return false
+	}
+	delete(r.data, id)
+	return true
+}

--- a/internal/product/service.go
+++ b/internal/product/service.go
@@ -1,0 +1,39 @@
+package product
+
+// Service defines business logic for products.
+type Service interface {
+	GetAll() []Product
+	GetByID(id int) (Product, bool)
+	Create(product Product) Product
+	Update(id int, product Product) (Product, bool)
+	Delete(id int) bool
+}
+
+type service struct {
+	repo Repository
+}
+
+// NewService creates a new Service.
+func NewService(r Repository) Service {
+	return &service{repo: r}
+}
+
+func (s *service) GetAll() []Product {
+	return s.repo.GetAll()
+}
+
+func (s *service) GetByID(id int) (Product, bool) {
+	return s.repo.GetByID(id)
+}
+
+func (s *service) Create(product Product) Product {
+	return s.repo.Create(product)
+}
+
+func (s *service) Update(id int, product Product) (Product, bool) {
+	return s.repo.Update(id, product)
+}
+
+func (s *service) Delete(id int) bool {
+	return s.repo.Delete(id)
+}

--- a/main.go
+++ b/main.go
@@ -9,12 +9,13 @@ import (
 
 	_ "test-backend/docs"
 	"test-backend/internal/auth"
+	"test-backend/internal/product"
 	"test-backend/internal/user"
 )
 
-// @title           User API
+// @title           User and Product API
 // @version         1.0
-// @description     Simple user API with Gin and Swagger
+// @description     Simple user and product API with Gin and Swagger
 
 // @host      localhost:8080
 // @BasePath  /
@@ -25,6 +26,10 @@ func main() {
 	repo := user.NewInMemoryRepository()
 	service := user.NewService(repo)
 	handler := user.NewHandler(service)
+
+	productRepo := product.NewInMemoryRepository()
+	productService := product.NewService(productRepo)
+	productHandler := product.NewHandler(productService)
 	jwtKey := []byte("secret")
 	authHandler := auth.NewHandler(service, jwtKey)
 
@@ -44,6 +49,12 @@ func main() {
 		authorized.POST("/users", handler.CreateUser)
 		authorized.PUT("/users/:id", handler.UpdateUser)
 		authorized.DELETE("/users/:id", handler.DeleteUser)
+
+		authorized.GET("/products", productHandler.GetProducts)
+		authorized.GET("/products/:id", productHandler.GetProduct)
+		authorized.POST("/products", productHandler.CreateProduct)
+		authorized.PUT("/products/:id", productHandler.UpdateProduct)
+		authorized.DELETE("/products/:id", productHandler.DeleteProduct)
 	}
 
 	if err := r.Run(":8080"); err != nil {


### PR DESCRIPTION
## Summary
- add product model, repository, service, and handlers
- register authorized /products CRUD routes
- regenerate Swagger docs including product endpoints

## Testing
- `swag init -g main.go -o docs`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68987f6ce234832a989bb1975da146c6